### PR TITLE
execute reboot after all tasks

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -11,9 +11,3 @@
 - name: restart ssh
   service: name=ssh state=restarted
   when: remote
-
-- name: reload vagrant
-  sudo: no
-  command: vagrant reload
-  delegate_to: 127.0.0.1
-  when: not remote

--- a/roles/partition/tasks/main.yml
+++ b/roles/partition/tasks/main.yml
@@ -13,7 +13,6 @@
 
 - name: activate swap
   command: swapon /swap.img
-  notify: reload vagrant
   when: ansible_swaptotal_mb < 1
 
 - name: register fstab

--- a/site.yml
+++ b/site.yml
@@ -10,3 +10,9 @@
     - {role: partition}
     - {role: redis}
     - {role: mariadb}
+  post_tasks:
+    - name: reload vagrant
+      sudo: no
+      command: vagrant reload
+      delegate_to: 127.0.0.1
+      when: not remote


### PR DESCRIPTION
The "notify" is executed after tasks but the order is 'task-executed'.
I want to execute `vagrant reload` after all tasks and all 'notify' tasks, so I declare `vagrant reload` as post_task.
