### PR TITLE
enable remote connecting to mariadb

### DIFF
--- a/roles/mariadb/files/mariadb_local.cnf.j2
+++ b/roles/mariadb/files/mariadb_local.cnf.j2
@@ -1,0 +1,127 @@
+#
+# The MySQL database server configuration file.
+#
+# You can copy this to one of:
+# - "/etc/mysql/my.cnf" to set global options,
+# - "~/.my.cnf" to set user-specific options.
+#
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# This will be passed to all mysql clients
+# It has been reported that passwords should be enclosed with ticks/quotes
+# escpecially if they contain "#" chars...
+# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
+[client]
+port            = 3306
+socket          = /var/run/mysqld/mysqld.sock
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+# This was formally known as [safe_mysqld]. Both versions are currently parsed.
+[mysqld_safe]
+socket          = /var/run/mysqld/mysqld.sock
+nice            = 0
+
+[mysqld]
+#
+# * Basic Settings
+#
+user            = mysql
+pid-file        = /var/run/mysqld/mysqld.pid
+socket          = /var/run/mysqld/mysqld.sock
+port            = 3306
+basedir         = /usr
+datadir         = /var/lib/mysql
+tmpdir          = /tmp
+lc-messages-dir = /usr/share/mysql
+skip-external-locking
+#
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+# bind-address            = 127.0.0.1
+#
+# * Fine Tuning
+#
+key_buffer              = 16M
+max_allowed_packet      = 16M
+thread_stack            = 192K
+thread_cache_size       = 8
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+myisam-recover         = BACKUP
+#max_connections        = 100
+#table_cache            = 64
+#thread_concurrency     = 10
+#
+# * Query Cache Configuration
+#
+query_cache_limit       = 1M
+query_cache_size        = 16M
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /var/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error log - should be very few entries.
+#
+log_error = /var/log/mysql/error.log
+#
+# Here you can see queries with especially long duration
+#log_slow_queries       = /var/log/mysql/mysql-slow.log
+#long_query_time = 2
+#log-queries-not-using-indexes
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id              = 1
+#log_bin                        = /var/log/mysql/mysql-bin.log
+expire_logs_days        = 10
+max_binlog_size         = 100M
+#binlog_do_db           = include_database_name
+#binlog_ignore_db       = include_database_name
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem
+
+
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet      = 16M
+
+[mysql]
+#no-auto-rehash # faster start of mysql but no tab completition
+
+[isamchk]
+key_buffer              = 16M
+
+#
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+!includedir /etc/mysql/conf.d/

--- a/roles/mariadb/handlers/main.yml
+++ b/roles/mariadb/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart mariadb-server
+  service: name=mysql state=restarted enabled=yes

--- a/roles/mariadb/tasks/install.yml
+++ b/roles/mariadb/tasks/install.yml
@@ -22,6 +22,10 @@
 - name: delete anonymous user for localhost
   mysql_user: user='' state=absent
 
+- name: remove bind-address
+  copy: src=mariadb_local.cnf.j2 dest=/etc/mysql/my.cnf mode=644
+  when: not remote
+
 - name: secure the root user
   mysql_user: user=root password={{ mariadb_root_password }} host={{ item }}
   with_items:
@@ -29,6 +33,12 @@
     - 127.0.0.1
     - localhost
     - "{{ ansible_hostname }}"
+
+- name: grant all privilege to root with grant option
+  mysql_user: user=root password={{ mariadb_root_password }} host=% priv={{ item }} append_privs=yes state=present
+  with_items:
+    - "*.*:ALL,GRANT"
+  notify: restart mariadb-server
 
 - name: remove the MySQL test database
   mysql_db: db=test state=absent


### PR DESCRIPTION
- move bind-address when 'remote' variable is false
- grant all privileges to root@%

(外から繋がらんかってん... :sweat_drops: )
- `bind-address` にクライアントのIP追加する(削除するとどのIPでも接続できる)
- `grant all privileges` で権限を与える
  (違いがよくわかっていない...)
